### PR TITLE
Bump setup-kind to 0.5.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
           dockerfile: package/Dockerfile.executor
           tags: e2e
       - name: Start KIND cluster
-        uses: engineerd/setup-kind@v0.4.0
+        uses: engineerd/setup-kind@v0.5.0
         with:
           name: e2e
       - name: Load executor image


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
for more details

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>