### PR TITLE
Conditionally rerun executions

### DIFF
--- a/pkg/apis/terraformcontroller.cattle.io/v1/types.go
+++ b/pkg/apis/terraformcontroller.cattle.io/v1/types.go
@@ -10,6 +10,7 @@ var (
 	ModuleConditionGitUpdated = condition.Cond("GitUpdated")
 
 	StateConditionJobDeployed      = condition.Cond("JobDeployed")
+	StateConfitionScheduled        = condition.Cond("RefreshScheduled")
 	ExecutionConditionMissingInfo  = condition.Cond("MissingInfo")
 	ExecutionConditionWatchRunning = condition.Cond("WatchRunning")
 	StateConditionDestroyed        = condition.Cond("Destroyed")
@@ -89,10 +90,11 @@ type StateSpec struct {
 }
 
 type StateStatus struct {
-	Conditions    []genericcondition.GenericCondition `json:"conditions,omitempty"`
-	LastRunHash   string                              `json:"lastRunHash,omitempty"`
-	ExecutionName string                              `json:"executionName,omitempty"`
-	StatePlanName string                              `json:"executionPlanName,omitempty"`
+	Conditions      []genericcondition.GenericCondition `json:"conditions,omitempty"`
+	RefreshSchedule metav1.Time                         `json:"schedule,omitempty"`
+	LastRunHash     string                              `json:"lastRunHash,omitempty"`
+	ExecutionName   string                              `json:"executionName,omitempty"`
+	StatePlanName   string                              `json:"executionPlanName,omitempty"`
 }
 
 // +genclient

--- a/pkg/terraform/state/deploy.go
+++ b/pkg/terraform/state/deploy.go
@@ -455,6 +455,11 @@ func generateRunHash(state *v1.State, vars map[string]string, h string, a string
 		fmt.Println("binary.Write failed:", err)
 	}
 
+	err = binary.Write(buf, binary.LittleEndian, state.Status.RefreshSchedule.Time.Unix())
+	if err != nil {
+		fmt.Println("binary.Write failed:", err)
+	}
+
 	hash := sha256.New()
 	if _, err := hash.Write([]byte(varHash)); err != nil {
 		logrus.Error("Failed to write to digest")

--- a/pkg/terraform/state/handler.go
+++ b/pkg/terraform/state/handler.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v1 "github.com/rancher/terraform-controller/pkg/apis/terraformcontroller.cattle.io/v1"
 	tfv1 "github.com/rancher/terraform-controller/pkg/generated/controllers/terraformcontroller.cattle.io/v1"
@@ -20,6 +21,7 @@ const (
 	ActionDestroy = "destroy"
 	//Default Image
 	DefaultExecutorImage = "rancher/terraform-controller-executor"
+	RefreshAnnotationKey = "terraformcontroller.cattle.io/run-every"
 )
 
 func NewHandler(
@@ -63,6 +65,7 @@ type handler struct {
 
 func (h *handler) OnChange(key string, obj *v1.State) (*v1.State, error) {
 	logrus.Debugf("State On Change Handler %s", key)
+	logrus.Infof("got update for %s", key)
 	if obj == nil {
 		return nil, nil
 	}
@@ -80,6 +83,21 @@ func (h *handler) OnChange(key string, obj *v1.State) (*v1.State, error) {
 	if !ok {
 		v1.ExecutionConditionMissingInfo.SetStatus(obj, err.Error())
 		logrus.Debugf("missing info %v", err.Error())
+		return h.states.Update(obj)
+	}
+
+	now := metaV1.Now()
+
+	if scheduleRefresh(obj, &now) && v1.StateConfitionScheduled.IsFalse(obj) {
+		duration, err := time.ParseDuration(obj.Annotations[RefreshAnnotationKey])
+		if err != nil {
+			logrus.Errorf("Failed to parse duration annotation: %s", err.Error())
+			return obj, err
+		}
+		schedule := metaV1.NewTime(now.Add(duration))
+
+		obj.Status.RefreshSchedule = schedule
+		v1.StateConfitionScheduled.True(obj)
 		return h.states.Update(obj)
 	}
 
@@ -137,7 +155,24 @@ func (h *handler) OnChange(key string, obj *v1.State) (*v1.State, error) {
 	v1.StateConditionJobDeployed.True(obj)
 	obj.Status.ExecutionName = exec.Name
 	obj.Status.LastRunHash = runHash
+
+	if obj.Annotations[RefreshAnnotationKey] != "" {
+		duration, err := time.ParseDuration(obj.Annotations[RefreshAnnotationKey])
+		if err != nil {
+			logrus.Errorf("Failed to parse duration annotation: %s", err.Error())
+			return obj, err
+		}
+		h.states.EnqueueAfter(obj.Namespace, obj.Name, duration)
+	}
 	return h.states.Update(obj)
+}
+
+func scheduleRefresh(obj *v1.State, now *metaV1.Time) bool {
+	expired := obj.Status.RefreshSchedule.Before(now)
+	if expired {
+		v1.StateConfitionScheduled.False(obj)
+	}
+	return expired && obj.Annotations[RefreshAnnotationKey] != ""
 }
 
 func (h *handler) OnRemove(key string, obj *v1.State) (*v1.State, error) {


### PR DESCRIPTION
Sometimes we want to ensure real world matches desired state, if state
annotated with "terraformcontroller.cattle.io/run-every" timestamp will
be used to generate new runHash and state update will be scheduled

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>