### PR TITLE
Watch all namespaces

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -219,7 +219,7 @@ func (e *E2E) getConfigMapEnv() *v1.ConfigMap {
 			Namespace: e.namespace,
 		},
 		Data: map[string]string{
-			"test_config_map_env": e.namespace,
+			"TF_VAR_test_config_map_env": e.namespace,
 		},
 	}
 }

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -19,16 +19,18 @@ import (
 )
 
 type E2E struct {
-	ctx        context.Context
-	cs         *kubernetes.Clientset
-	cfg        *rest.Config
-	kubeconfig string
-	namespace  string
-	module_url string
-	crds       []crd.CRD
+	ctx            context.Context
+	cs             *kubernetes.Clientset
+	cfg            *rest.Config
+	kubeconfig     string
+	ctrl_namespace string
+	namespace      string
+	module_url     string
+	name           string
+	crds           []crd.CRD
 }
 
-func NewE2E(namespace, kubeconfig, module string, crdsNames []string) *E2E {
+func NewE2E(name, namespace, kubeconfig, module string, crdsNames []string) *E2E {
 	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		logrus.Fatalf("Error building kubeconfig: %s", err.Error())
@@ -45,13 +47,15 @@ func NewE2E(namespace, kubeconfig, module string, crdsNames []string) *E2E {
 	}
 
 	return &E2E{
-		ctx:        signals.SetupSignalHandler(context.Background()),
-		cs:         cs,
-		cfg:        cfg,
-		kubeconfig: kubeconfig,
-		namespace:  namespace,
-		module_url: module,
-		crds:       crds,
+		ctx:            signals.SetupSignalHandler(context.Background()),
+		cs:             cs,
+		cfg:            cfg,
+		kubeconfig:     kubeconfig,
+		ctrl_namespace: name,
+		namespace:      namespace,
+		name:           name,
+		module_url:     module,
+		crds:           crds,
 	}
 }
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	NAMESPACE       = "terraform-controller"
+	NAME            = "terraform-controller"
+	NAMESPACE       = "app"
 	MODULE_URL      = "https://github.com/luthermonson/terraform-controller-test-module"
 	TEST_CONFIG_MAP = "test-config-map"
 )
@@ -30,12 +31,8 @@ func TestMain(m *testing.M) {
 	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
 		logrus.Fatal("kubeconfig file does not exist")
 	}
-	namespace := os.Getenv("NAMESPACE")
-	if namespace == "" {
-		namespace = NAMESPACE
-	}
 
-	e = NewE2E(namespace, kubeconfig, MODULE_URL, []string{
+	e = NewE2E(NAME, NAMESPACE, kubeconfig, MODULE_URL, []string{
 		"Module",
 		"State",
 		"Execution",

--- a/e2e/init.go
+++ b/e2e/init.go
@@ -25,6 +25,10 @@ func (e *E2E) initialize() error {
 		return err
 	}
 
+	_, err = e.cs.CoreV1().Namespaces().Create(e.ctx, e.getCtrlNs(), v13.CreateOptions{})
+	if err != nil {
+		return err
+	}
 	_, err = e.cs.CoreV1().Namespaces().Create(e.ctx, e.getNs(), v13.CreateOptions{})
 	if err != nil {
 		return err
@@ -34,13 +38,13 @@ func (e *E2E) initialize() error {
 		return err
 	}
 
-	_, err = e.cs.CoreV1().ServiceAccounts(e.namespace).Create(e.ctx, e.getSa(), v13.CreateOptions{})
+	_, err = e.cs.CoreV1().ServiceAccounts(e.ctrl_namespace).Create(e.ctx, e.getSa(), v13.CreateOptions{})
 	if err != nil {
 		return err
 	}
 
 	err = wait.Poll(time.Second, 15*time.Second, func() (bool, error) {
-		_, err := e.cs.CoreV1().ServiceAccounts(e.namespace).Get(e.ctx, e.namespace, v13.GetOptions{})
+		_, err := e.cs.CoreV1().ServiceAccounts(e.ctrl_namespace).Get(e.ctx, e.name, v13.GetOptions{})
 		if err == nil {
 			return true, nil
 		}
@@ -67,15 +71,22 @@ func (e *E2E) getNs() *v12.Namespace {
 		},
 	}
 }
+func (e *E2E) getCtrlNs() *v12.Namespace {
+	return &v12.Namespace{
+		ObjectMeta: v13.ObjectMeta{
+			Name: e.name,
+		},
+	}
+}
 
 func (e *E2E) getSa() *v12.ServiceAccount {
 	return &v12.ServiceAccount{
 		ObjectMeta: v13.ObjectMeta{
-			Name:      e.namespace,
-			Namespace: e.namespace,
+			Name:      e.name,
+			Namespace: e.ctrl_namespace,
 			Labels: map[string]string{
 				"apps.kubernetes.io/component": "controller",
-				"apps.kubernetes.io/name":      e.namespace,
+				"apps.kubernetes.io/name":      e.name,
 			},
 		},
 	}
@@ -84,10 +95,10 @@ func (e *E2E) getSa() *v12.ServiceAccount {
 func (e *E2E) getCrb() *v1.ClusterRoleBinding {
 	return &v1.ClusterRoleBinding{
 		ObjectMeta: v13.ObjectMeta{
-			Name: e.namespace,
+			Name: e.name,
 			Labels: map[string]string{
 				"apps.kubernetes.io/component": "controller",
-				"apps.kubernetes.io/name":      e.namespace,
+				"apps.kubernetes.io/name":      e.name,
 			},
 		},
 		RoleRef: v1.RoleRef{
@@ -98,8 +109,8 @@ func (e *E2E) getCrb() *v1.ClusterRoleBinding {
 		Subjects: []v1.Subject{
 			{
 				Kind:      "ServiceAccount",
-				Name:      e.namespace,
-				Namespace: e.namespace,
+				Name:      e.name,
+				Namespace: e.ctrl_namespace,
 			},
 		},
 	}

--- a/e2e/init_test.go
+++ b/e2e/init_test.go
@@ -37,25 +37,25 @@ func lowerPlural(s string) string {
 
 func TestGetNs(t *testing.T) {
 	assert := assert.New(t)
-	ns := e.getNs()
+	ns := e.getCtrlNs()
 	assert.Equal(reflect.TypeOf(ns), reflect.TypeOf(&corev1.Namespace{}))
-	assert.Equal(ns.ObjectMeta.Name, e.namespace)
+	assert.Equal(ns.ObjectMeta.Name, e.ctrl_namespace)
 }
 
 func TestGetSa(t *testing.T) {
 	assert := assert.New(t)
 	sa := e.getSa()
 	assert.Equal(reflect.TypeOf(sa), reflect.TypeOf(&corev1.ServiceAccount{}))
-	assert.Equal(sa.ObjectMeta.Name, e.namespace)
-	assert.Equal(sa.ObjectMeta.Namespace, e.namespace)
+	assert.Equal(sa.ObjectMeta.Name, e.name)
+	assert.Equal(sa.ObjectMeta.Namespace, e.ctrl_namespace)
 }
 
 func TestGetCrb(t *testing.T) {
 	assert := assert.New(t)
 	crb := e.getCrb()
 	assert.Equal(reflect.TypeOf(crb), reflect.TypeOf(&rbacv1.ClusterRoleBinding{}))
-	assert.Equal(crb.ObjectMeta.Name, e.namespace)
+	assert.Equal(crb.ObjectMeta.Name, e.name)
 	assert.Equal(crb.Subjects[0].Kind, "ServiceAccount")
-	assert.Equal(crb.Subjects[0].Name, e.namespace)
-	assert.Equal(crb.Subjects[0].Namespace, e.namespace)
+	assert.Equal(crb.Subjects[0].Name, e.name)
+	assert.Equal(crb.Subjects[0].Namespace, e.ctrl_namespace)
 }

--- a/main.go
+++ b/main.go
@@ -54,11 +54,6 @@ func main() {
 			Value:  "${HOME}/.kube/config",
 		},
 		cli.StringFlag{
-			Name:   "namespace",
-			EnvVar: "NAMESPACE",
-			Value:  "default",
-		},
-		cli.StringFlag{
 			Name:   "masterurl",
 			EnvVar: "MASTERURL",
 			Value:  "",
@@ -91,9 +86,8 @@ func run(c *cli.Context) {
 
 	threadiness := c.Int("threads")
 	masterurl := c.String("masterurl")
-	ns := c.String("namespace")
 
-	logrus.Printf("Booting Terraform Controller, namespace: %s", ns)
+	logrus.Println("Booting Terraform Controller")
 
 	ctx := signals.SetupSignalHandler(context.Background())
 
@@ -102,22 +96,22 @@ func run(c *cli.Context) {
 		logrus.Fatalf("Error building kubeconfig: %s", err.Error())
 	}
 
-	tfFactory, err := terraformcontroller.NewFactoryFromConfigWithNamespace(cfg, ns)
+	tfFactory, err := terraformcontroller.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building terraform controllers: %s", err.Error())
 	}
 
-	coreFactory, err := core.NewFactoryFromConfigWithNamespace(cfg, ns)
+	coreFactory, err := core.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building core controllers: %s", err.Error())
 	}
 
-	rbacFactory, err := rbac.NewFactoryFromConfigWithNamespace(cfg, ns)
+	rbacFactory, err := rbac.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building rbac controllers: %s", err.Error())
 	}
 
-	batchFactory, err := batch.NewFactoryFromConfigWithNamespace(cfg, ns)
+	batchFactory, err := batch.NewFactoryFromConfig(cfg)
 	if err != nil {
 		logrus.Fatalf("Error building rbac controllers: %s", err.Error())
 	}
@@ -141,7 +135,7 @@ func run(c *cli.Context) {
 
 	<-ctx.Done()
 	}()
-	cont := types.NewContext(ns, tfFactory, coreFactory)
+	cont := types.NewContext(tfFactory, coreFactory)
 	logrus.Info("Setting up webhook listener")
 	addr := c.String("listen")
 	handler := hooks.HandleHooks(cont)

--- a/pkg/provider/github/github.go
+++ b/pkg/provider/github/github.go
@@ -21,12 +21,10 @@ const (
 type GitHub struct {
 	modules     tfv1controller.ModuleController
 	secretCache corev1controller.SecretCache
-	namespace   string
 }
 
 func NewGitHub(rContext *types.Context) *GitHub {
 	return &GitHub{
-		namespace:   rContext.Namespace,
 		modules:     rContext.Tfv1.Terraformcontroller().V1().Module(),
 		secretCache: rContext.Core.Core().V1().Secret().Cache(),
 	}

--- a/pkg/types/context.go
+++ b/pkg/types/context.go
@@ -7,15 +7,13 @@ import (
 )
 
 type Context struct {
-	Namespace string
 	Tfv1   *tfv1.Factory
 	Core   *core.Factory
 }
-func NewContext(namespace string, tfFactory *tfv1.Factory, coreFactory *core.Factory) *Context {
+func NewContext(tfFactory *tfv1.Factory, coreFactory *core.Factory) *Context {
 	context := &Context{
-		Namespace: namespace,
-			Tfv1:      tfFactory,
-			Core:      coreFactory,
+		Tfv1:      tfFactory,
+		Core:      coreFactory,
 	}
 	return context
 }

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -37,7 +37,6 @@ k3s ctr images import --base-name terraform-controller-executor artifacts/images
 k3s kubectl rollout status deployment coredns -n kube-system # make sure coredns is actually running
 
 export KUBECONFIG=$kubeconfig
-export NAMESPACE=terraform-controller
 
 ./bin/terraform-controller --threads 1&
 tfc_pid=$!


### PR DESCRIPTION
* Drop namespace option
* Change e2e in a way controller and objects are splitted into separate
  namespaces.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>