### PR TITLE
Don't limit buffer in size

### DIFF
--- a/pkg/cmd/impl.go
+++ b/pkg/cmd/impl.go
@@ -40,7 +40,7 @@ func execute(command Command, storedStdout *[]string, storedStderr *[]string) er
 		return err
 	}
 
-	if err := readStdoutAndStderr(stdout, stderr, storedStdout, storedStderr, 1024); err != nil {
+	if err := readStdoutAndStderr(stdout, stderr, storedStdout, storedStderr, 0); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is rather quick fix. When terraform outputs too much
log data, process got stuck. Final solution to be found.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>